### PR TITLE
🔀 :: [#23] - 자체 회원가입 로직 추가

### DIFF
--- a/src/main/kotlin/com/practice/oauth2/domain/auth/exception/AlreadyExistsUserException.kt
+++ b/src/main/kotlin/com/practice/oauth2/domain/auth/exception/AlreadyExistsUserException.kt
@@ -1,0 +1,6 @@
+package com.practice.oauth2.domain.auth.exception
+
+import com.novalink.simpleparkingserver.global.error.code.ErrorCode
+import com.practice.oauth2.global.error.BasicException
+
+class AlreadyExistsUserException : BasicException(ErrorCode.ALREADY_EXISTS_USER)

--- a/src/main/kotlin/com/practice/oauth2/domain/auth/presentation/AuthController.kt
+++ b/src/main/kotlin/com/practice/oauth2/domain/auth/presentation/AuthController.kt
@@ -1,0 +1,22 @@
+package com.practice.oauth2.domain.auth.presentation
+
+import com.practice.oauth2.domain.auth.presentation.data.extension.toDto
+import com.practice.oauth2.domain.auth.presentation.data.request.SignupRequest
+import com.practice.oauth2.domain.auth.service.AuthService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/auth")
+class AuthController(
+    private val authService: AuthService
+) {
+    @PostMapping("/signup")
+    fun signup(@RequestBody signupRequest: SignupRequest): ResponseEntity<Void> =
+        authService.signup(signupRequest.toDto())
+            .run { ResponseEntity(HttpStatus.CREATED) }
+}

--- a/src/main/kotlin/com/practice/oauth2/domain/auth/presentation/data/extension/AuthRequestExtension.kt
+++ b/src/main/kotlin/com/practice/oauth2/domain/auth/presentation/data/extension/AuthRequestExtension.kt
@@ -1,0 +1,12 @@
+package com.practice.oauth2.domain.auth.presentation.data.extension
+
+import com.practice.oauth2.domain.auth.presentation.data.request.SignupRequest
+import com.practice.oauth2.domain.auth.service.dto.request.SignupReqDto
+
+fun SignupRequest.toDto(): SignupReqDto =
+    SignupReqDto(
+        email = this.email,
+        password = this.password,
+        name = this.name,
+        imageUrl = this.imageUrl
+    )

--- a/src/main/kotlin/com/practice/oauth2/domain/auth/presentation/data/request/SignupRequest.kt
+++ b/src/main/kotlin/com/practice/oauth2/domain/auth/presentation/data/request/SignupRequest.kt
@@ -1,0 +1,8 @@
+package com.practice.oauth2.domain.auth.presentation.data.request
+
+data class SignupRequest(
+    val email: String,
+    val password: String,
+    val name: String,
+    val imageUrl: String
+)

--- a/src/main/kotlin/com/practice/oauth2/domain/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/practice/oauth2/domain/auth/service/AuthService.kt
@@ -1,0 +1,26 @@
+package com.practice.oauth2.domain.auth.service
+
+import com.practice.oauth2.domain.auth.exception.AlreadyExistsUserException
+import com.practice.oauth2.domain.auth.service.dto.extension.toEntity
+import com.practice.oauth2.domain.auth.service.dto.request.SignupReqDto
+import com.practice.oauth2.domain.user.entity.repository.UserRepository
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class AuthService(
+    private val userRepository: UserRepository,
+    private val passwordEncoder: PasswordEncoder
+) {
+    @Transactional(rollbackFor = [Exception::class])
+    fun signup(signupReqDto: SignupReqDto) {
+        if (userRepository.existsByEmail(signupReqDto.email))
+            throw AlreadyExistsUserException()
+
+        val encodedPassword = passwordEncoder.encode(signupReqDto.password)
+
+        val user = signupReqDto.toEntity(encodedPassword)
+        userRepository.save(user)
+    }
+}

--- a/src/main/kotlin/com/practice/oauth2/domain/auth/service/dto/extension/AuthReqDtoExtension.kt
+++ b/src/main/kotlin/com/practice/oauth2/domain/auth/service/dto/extension/AuthReqDtoExtension.kt
@@ -1,0 +1,17 @@
+package com.practice.oauth2.domain.auth.service.dto.extension
+
+import com.practice.oauth2.domain.auth.service.dto.request.SignupReqDto
+import com.practice.oauth2.domain.user.entity.User
+import com.practice.oauth2.domain.user.entity.enums.Role
+import com.practice.oauth2.domain.user.entity.enums.SocialType
+
+fun SignupReqDto.toEntity(encodedPassword: String): User =
+    User(
+        email = this.email,
+        password = encodedPassword,
+        name = this.name,
+        profileImgUrl = imageUrl,
+        socialId = "",
+        socialType = SocialType.ORIGINAL,
+        roles = listOf(Role.ROLE_USER)
+    )

--- a/src/main/kotlin/com/practice/oauth2/domain/auth/service/dto/request/SignupReqDto.kt
+++ b/src/main/kotlin/com/practice/oauth2/domain/auth/service/dto/request/SignupReqDto.kt
@@ -1,0 +1,8 @@
+package com.practice.oauth2.domain.auth.service.dto.request
+
+data class SignupReqDto(
+    val email: String,
+    val password: String,
+    val name: String,
+    val imageUrl: String
+)

--- a/src/main/kotlin/com/practice/oauth2/domain/user/entity/repository/UserRepository.kt
+++ b/src/main/kotlin/com/practice/oauth2/domain/user/entity/repository/UserRepository.kt
@@ -7,4 +7,5 @@ import java.util.UUID
 
 interface UserRepository : JpaRepository<User, UUID> {
     fun findUserBySocialIdAndSocialType(socialId: String, socialType: SocialType): User?
+    fun existsByEmail(email: String): Boolean
 }

--- a/src/main/kotlin/com/practice/oauth2/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/practice/oauth2/global/config/SecurityConfig.kt
@@ -11,6 +11,7 @@ import com.practice.oauth2.global.security.CustomAccessDeniedHandler
 import com.practice.oauth2.global.security.CustomAuthenticationEntryPoint
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
@@ -42,6 +43,9 @@ class SecurityConfig(
             it.requestMatchers(RequestMatcher { request ->
                 CorsUtils.isPreFlightRequest(request)
             }).permitAll()
+
+            // auth
+            it.requestMatchers(HttpMethod.POST, "/auth/signup").permitAll()
 
             it.anyRequest().denyAll()
         }


### PR DESCRIPTION
## 개요
* 자체 회원가입 API를 작성합니다.
## 작업내용
* UserRepository에 existsByEmail 메서드 추가
* SignupReqDto 추가
* AlreadyExistsUserException 추가
* 자체 회원가입 로직 추가
* 회원가입 요청 객체 추가
* 회원가입 엔드포인트 추가
* 회원가입 엔드포인트에 권한 설정 추가