### PR TITLE
🔀 :: [#25] - 자체 로그인 API 추가

### DIFF
--- a/src/main/kotlin/com/practice/oauth2/domain/auth/presentation/AuthController.kt
+++ b/src/main/kotlin/com/practice/oauth2/domain/auth/presentation/AuthController.kt
@@ -1,7 +1,10 @@
 package com.practice.oauth2.domain.auth.presentation
 
 import com.practice.oauth2.domain.auth.presentation.data.extension.toDto
+import com.practice.oauth2.domain.auth.presentation.data.extension.toResponse
+import com.practice.oauth2.domain.auth.presentation.data.request.SignInRequest
 import com.practice.oauth2.domain.auth.presentation.data.request.SignupRequest
+import com.practice.oauth2.domain.auth.presentation.data.response.TokenResponse
 import com.practice.oauth2.domain.auth.service.AuthService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -19,4 +22,9 @@ class AuthController(
     fun signup(@RequestBody signupRequest: SignupRequest): ResponseEntity<Void> =
         authService.signup(signupRequest.toDto())
             .run { ResponseEntity(HttpStatus.CREATED) }
+
+    @PostMapping
+    fun signIn(@RequestBody signInRequest: SignInRequest): ResponseEntity<TokenResponse> =
+        authService.signIn(signInRequest.toDto())
+            .let { ResponseEntity.ok(it.toResponse()) }
 }

--- a/src/main/kotlin/com/practice/oauth2/domain/auth/presentation/data/extension/AuthRequestExtension.kt
+++ b/src/main/kotlin/com/practice/oauth2/domain/auth/presentation/data/extension/AuthRequestExtension.kt
@@ -1,6 +1,8 @@
 package com.practice.oauth2.domain.auth.presentation.data.extension
 
+import com.practice.oauth2.domain.auth.presentation.data.request.SignInRequest
 import com.practice.oauth2.domain.auth.presentation.data.request.SignupRequest
+import com.practice.oauth2.domain.auth.service.dto.request.SignInReqDto
 import com.practice.oauth2.domain.auth.service.dto.request.SignupReqDto
 
 fun SignupRequest.toDto(): SignupReqDto =
@@ -9,4 +11,10 @@ fun SignupRequest.toDto(): SignupReqDto =
         password = this.password,
         name = this.name,
         imageUrl = this.imageUrl
+    )
+
+fun SignInRequest.toDto(): SignInReqDto =
+    SignInReqDto(
+        email = this.email,
+        password = this.password
     )

--- a/src/main/kotlin/com/practice/oauth2/domain/auth/presentation/data/extension/AuthResponseExtension.kt
+++ b/src/main/kotlin/com/practice/oauth2/domain/auth/presentation/data/extension/AuthResponseExtension.kt
@@ -1,0 +1,11 @@
+package com.practice.oauth2.domain.auth.presentation.data.extension
+
+import com.practice.oauth2.domain.auth.presentation.data.response.TokenResponse
+import com.practice.oauth2.domain.auth.service.dto.response.TokenResDto
+
+fun TokenResDto.toResponse(): TokenResponse =
+    TokenResponse(
+        accessToken = this.accessToken,
+        refreshToken = this.refreshToken,
+        accessExpiredTime = this.accessExpires
+    )

--- a/src/main/kotlin/com/practice/oauth2/domain/auth/presentation/data/request/SignInRequest.kt
+++ b/src/main/kotlin/com/practice/oauth2/domain/auth/presentation/data/request/SignInRequest.kt
@@ -1,0 +1,6 @@
+package com.practice.oauth2.domain.auth.presentation.data.request
+
+data class SignInRequest(
+    val email: String,
+    val password: String
+)

--- a/src/main/kotlin/com/practice/oauth2/domain/auth/presentation/data/response/TokenResponse.kt
+++ b/src/main/kotlin/com/practice/oauth2/domain/auth/presentation/data/response/TokenResponse.kt
@@ -1,4 +1,4 @@
-package com.practice.oauth2.domain.user.presentation.data.response
+package com.practice.oauth2.domain.auth.presentation.data.response
 
 import java.time.ZonedDateTime
 

--- a/src/main/kotlin/com/practice/oauth2/domain/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/practice/oauth2/domain/auth/service/AuthService.kt
@@ -2,8 +2,12 @@ package com.practice.oauth2.domain.auth.service
 
 import com.practice.oauth2.domain.auth.exception.AlreadyExistsUserException
 import com.practice.oauth2.domain.auth.service.dto.extension.toEntity
+import com.practice.oauth2.domain.auth.service.dto.request.SignInReqDto
 import com.practice.oauth2.domain.auth.service.dto.request.SignupReqDto
+import com.practice.oauth2.domain.auth.service.dto.response.TokenResDto
 import com.practice.oauth2.domain.user.entity.repository.UserRepository
+import com.practice.oauth2.domain.user.exception.UserNotFoundException
+import com.practice.oauth2.global.jwt.util.TokenGenerator
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -11,7 +15,8 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class AuthService(
     private val userRepository: UserRepository,
-    private val passwordEncoder: PasswordEncoder
+    private val passwordEncoder: PasswordEncoder,
+    private val tokenGenerator: TokenGenerator
 ) {
     @Transactional(rollbackFor = [Exception::class])
     fun signup(signupReqDto: SignupReqDto) {
@@ -22,5 +27,16 @@ class AuthService(
 
         val user = signupReqDto.toEntity(encodedPassword)
         userRepository.save(user)
+    }
+
+    @Transactional(rollbackFor = [Exception::class])
+    fun signIn(signInReqDto: SignInReqDto): TokenResDto {
+        val user = (userRepository.findByEmail(signInReqDto.email)
+            ?: throw UserNotFoundException())
+
+        val accessToken = tokenGenerator.generateAccessToken(user.id.toString())
+        val refreshToken = tokenGenerator.generateRefreshToken(user.id.toString())
+        val accessExpiredTime = tokenGenerator.getAccessExpiredTime()
+        return TokenResDto(accessToken, refreshToken, accessExpiredTime)
     }
 }

--- a/src/main/kotlin/com/practice/oauth2/domain/auth/service/dto/request/SignInReqDto.kt
+++ b/src/main/kotlin/com/practice/oauth2/domain/auth/service/dto/request/SignInReqDto.kt
@@ -1,0 +1,6 @@
+package com.practice.oauth2.domain.auth.service.dto.request
+
+data class SignInReqDto(
+    val email: String,
+    val password: String
+)

--- a/src/main/kotlin/com/practice/oauth2/domain/auth/service/dto/response/TokenResDto.kt
+++ b/src/main/kotlin/com/practice/oauth2/domain/auth/service/dto/response/TokenResDto.kt
@@ -1,0 +1,9 @@
+package com.practice.oauth2.domain.auth.service.dto.response
+
+import java.time.ZonedDateTime
+
+data class TokenResDto(
+    val accessToken: String,
+    val refreshToken: String,
+    val accessExpires: ZonedDateTime
+)

--- a/src/main/kotlin/com/practice/oauth2/domain/user/entity/repository/UserRepository.kt
+++ b/src/main/kotlin/com/practice/oauth2/domain/user/entity/repository/UserRepository.kt
@@ -8,4 +8,5 @@ import java.util.UUID
 interface UserRepository : JpaRepository<User, UUID> {
     fun findUserBySocialIdAndSocialType(socialId: String, socialType: SocialType): User?
     fun existsByEmail(email: String): Boolean
+    fun findByEmail(email: String): User?
 }

--- a/src/main/kotlin/com/practice/oauth2/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/practice/oauth2/global/config/SecurityConfig.kt
@@ -46,6 +46,7 @@ class SecurityConfig(
 
             // auth
             it.requestMatchers(HttpMethod.POST, "/auth/signup").permitAll()
+            it.requestMatchers(HttpMethod.POST, "/auth").permitAll()
 
             it.anyRequest().denyAll()
         }

--- a/src/main/kotlin/com/practice/oauth2/global/oauth/handler/OAuthLoginSuccessHandler.kt
+++ b/src/main/kotlin/com/practice/oauth2/global/oauth/handler/OAuthLoginSuccessHandler.kt
@@ -1,7 +1,7 @@
 package com.practice.oauth2.global.oauth.handler
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.practice.oauth2.domain.user.presentation.data.response.TokenResponse
+import com.practice.oauth2.domain.auth.presentation.data.response.TokenResponse
 import com.practice.oauth2.global.jwt.util.TokenGenerator
 import com.practice.oauth2.global.oauth.CustomOAuthUser
 import jakarta.servlet.http.HttpServletRequest


### PR DESCRIPTION
## 개요
* 자체 로그인 API를 추가합니다.
## 작업내용
* TokenResponse를 auth 패키지 하위로 이동
* findByEmail 메서드 추가
* SignInReqDto 추가
* TokenResDto 추가
* 자체 로그인 로직 추가
* SignInRequest 추가
* 자체 로그인 엔드포인트 추가
* 자체 로그인 엔드포인트에 권한 설정 추가