### PR TITLE
🔀 :: [#35] - OAuth 중복 가입을 방지하는 로직 추가

### DIFF
--- a/src/main/kotlin/com/practice/oauth2/domain/user/entity/repository/UserRepository.kt
+++ b/src/main/kotlin/com/practice/oauth2/domain/user/entity/repository/UserRepository.kt
@@ -7,6 +7,7 @@ import java.util.UUID
 
 interface UserRepository : JpaRepository<User, UUID> {
     fun findUserBySocialIdAndSocialType(socialId: String, socialType: SocialType): User?
+    fun existsByEmailAndSocialTypeNot(email: String, socialType: SocialType): Boolean
     fun existsByEmail(email: String): Boolean
     fun findByEmail(email: String): User?
 }

--- a/src/main/kotlin/com/practice/oauth2/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/practice/oauth2/global/config/SecurityConfig.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.practice.oauth2.global.error.filter.ExceptionFilter
 import com.practice.oauth2.global.jwt.filter.JwtReqFilter
 import com.practice.oauth2.global.jwt.util.TokenParser
+import com.practice.oauth2.global.oauth.filter.OAuthExceptionFilter
 import com.practice.oauth2.global.oauth.handler.OAuthLoginFailureHandler
 import com.practice.oauth2.global.oauth.handler.OAuthLoginSuccessHandler
 import com.practice.oauth2.global.oauth.service.CustomOAuthUserService
@@ -16,6 +17,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.security.web.util.matcher.RequestMatcher
@@ -64,6 +66,7 @@ class SecurityConfig(
         http
             .addFilterBefore(ExceptionFilter(objectMapper), UsernamePasswordAuthenticationFilter::class.java)
             .addFilterBefore(JwtReqFilter(tokenParser), UsernamePasswordAuthenticationFilter::class.java)
+            .addFilterBefore(OAuthExceptionFilter(objectMapper), OAuth2LoginAuthenticationFilter::class.java)
 
         http
             .exceptionHandling {

--- a/src/main/kotlin/com/practice/oauth2/global/error/code/ErrorCode.kt
+++ b/src/main/kotlin/com/practice/oauth2/global/error/code/ErrorCode.kt
@@ -29,4 +29,5 @@ enum class ErrorCode(
 
     //OAuth
     OAUTH_LOGIN_FAILURE(HttpStatus.FORBIDDEN.value(), 40001, "social login fails"),
+    INVALID_SOCIAL_TYPE(HttpStatus.BAD_REQUEST.value(), 40002, "this social type is invalid"),
 }

--- a/src/main/kotlin/com/practice/oauth2/global/oauth/exception/InvalidSocialTypeException.kt
+++ b/src/main/kotlin/com/practice/oauth2/global/oauth/exception/InvalidSocialTypeException.kt
@@ -1,0 +1,7 @@
+package com.practice.oauth2.global.oauth.exception
+
+import com.novalink.simpleparkingserver.global.error.code.ErrorCode
+import com.practice.oauth2.global.error.BasicException
+
+class InvalidSocialTypeException : BasicException(ErrorCode.INVALID_SOCIAL_TYPE) {
+}

--- a/src/main/kotlin/com/practice/oauth2/global/oauth/filter/OAuthExceptionFilter.kt
+++ b/src/main/kotlin/com/practice/oauth2/global/oauth/filter/OAuthExceptionFilter.kt
@@ -1,0 +1,53 @@
+package com.practice.oauth2.global.oauth.filter
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.novalink.simpleparkingserver.global.error.code.ErrorCode
+import com.practice.oauth2.global.error.BasicException
+import com.practice.oauth2.global.error.response.ErrorResponse
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.web.filter.OncePerRequestFilter
+
+class OAuthExceptionFilter(
+    private val objectMapper: ObjectMapper,
+) : OncePerRequestFilter() {
+    private val log = LoggerFactory.getLogger(this::class.simpleName)
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        try {
+            filterChain.doFilter(request, response)
+        } catch (ex: Exception) {
+            when(ex) {
+                is BasicException -> {
+                    logErrorResponse(request, ex.errorCode)
+                    writeErrorResponse(response, ex)
+                }
+                else -> {
+                    val errorCode = ErrorCode.INTERNAL_ERROR
+                    logErrorResponse(request, errorCode)
+                    writeErrorResponse(response, BasicException(errorCode))
+                }
+            }
+        }
+    }
+
+    private fun logErrorResponse(request: HttpServletRequest, errorCode: ErrorCode) {
+        log.error(request.method)
+        log.error(request.requestURI)
+        log.error(errorCode.message)
+        log.error("${errorCode.code}")
+    }
+    private fun writeErrorResponse(response: HttpServletResponse, exception: BasicException) {
+        val errorCode = exception.errorCode
+        val responseBody = objectMapper.writeValueAsString(ErrorResponse(errorCode))
+        response.status = errorCode.code
+        response.characterEncoding = Charsets.UTF_8.name()
+        response.contentType = "application/json"
+        response.writer.write(responseBody)
+    }
+}

--- a/src/main/kotlin/com/practice/oauth2/global/oauth/service/CustomOAuthUserService.kt
+++ b/src/main/kotlin/com/practice/oauth2/global/oauth/service/CustomOAuthUserService.kt
@@ -1,5 +1,6 @@
 package com.practice.oauth2.global.oauth.service
 
+import com.practice.oauth2.domain.auth.exception.AlreadyExistsUserException
 import com.practice.oauth2.domain.user.entity.User
 import com.practice.oauth2.domain.user.entity.enums.SocialType
 import com.practice.oauth2.domain.user.entity.repository.UserRepository
@@ -52,7 +53,7 @@ class CustomOAuthUserService(
     private fun getUser(attributes: OAuthAttributes, socialType: SocialType): User {
         val socialId = attributes.oauthUserInfo.getId()
         if (userRepository.existsByEmailAndSocialTypeNot(attributes.oauthUserInfo.getEmail(), socialType))
-            throw RuntimeException()
+            throw AlreadyExistsUserException()
         return userRepository.findUserBySocialIdAndSocialType(socialId, socialType)
             ?: saveUser(attributes, socialType)
     }

--- a/src/main/kotlin/com/practice/oauth2/global/oauth/service/CustomOAuthUserService.kt
+++ b/src/main/kotlin/com/practice/oauth2/global/oauth/service/CustomOAuthUserService.kt
@@ -51,6 +51,8 @@ class CustomOAuthUserService(
 
     private fun getUser(attributes: OAuthAttributes, socialType: SocialType): User {
         val socialId = attributes.oauthUserInfo.getId()
+        if (userRepository.existsByEmailAndSocialTypeNot(attributes.oauthUserInfo.getEmail(), socialType))
+            throw RuntimeException()
         return userRepository.findUserBySocialIdAndSocialType(socialId, socialType)
             ?: saveUser(attributes, socialType)
     }

--- a/src/main/kotlin/com/practice/oauth2/global/oauth/service/CustomOAuthUserService.kt
+++ b/src/main/kotlin/com/practice/oauth2/global/oauth/service/CustomOAuthUserService.kt
@@ -6,6 +6,7 @@ import com.practice.oauth2.domain.user.entity.enums.SocialType
 import com.practice.oauth2.domain.user.entity.repository.UserRepository
 import com.practice.oauth2.global.oauth.CustomOAuthUser
 import com.practice.oauth2.global.oauth.OAuthAttributes
+import com.practice.oauth2.global.oauth.exception.InvalidSocialTypeException
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService
@@ -47,7 +48,7 @@ class CustomOAuthUserService(
         when(registrationId) {
             OAuthPrefix.KAKAO -> SocialType.KAKAO
             OAuthPrefix.NAVER -> SocialType.NAVER
-            else -> throw RuntimeException()
+            else -> throw InvalidSocialTypeException()
         }
 
     private fun getUser(attributes: OAuthAttributes, socialType: SocialType): User {


### PR DESCRIPTION
## 개요
* OAuth 로그인시에 중복 가입을 방지하는 로직을 추가합니다.
## 작업내용
* 중복 가입시도를 체크하는 메서드 추가
* AlreadyExistsUserException 추가
* 중복 가입 시도일때 예외발생
* InvalidSocialTypeException 추가
* CustomOAuthUserService에서 제공하지 않는 소셜타입일때 InvalidSocialTypeException을 발생시키게끔 수정
* OAuthExceptionFilter 추가