### PR TITLE
🔀 :: [#39] - 소셜 타입이 올바르지 않을때 커스텀 예외를 반환하도록 리펙토링

### DIFF
--- a/src/main/kotlin/com/practice/oauth2/global/oauth/OAuthAttributes.kt
+++ b/src/main/kotlin/com/practice/oauth2/global/oauth/OAuthAttributes.kt
@@ -3,6 +3,7 @@ package com.practice.oauth2.global.oauth
 import com.practice.oauth2.domain.user.entity.User
 import com.practice.oauth2.domain.user.entity.enums.Role
 import com.practice.oauth2.domain.user.entity.enums.SocialType
+import com.practice.oauth2.global.oauth.exception.InvalidSocialTypeException
 import com.practice.oauth2.global.oauth.user.GoogleOAuthUserInfo
 import com.practice.oauth2.global.oauth.user.KakaoOAuthUserInfo
 import com.practice.oauth2.global.oauth.user.NaverOAuthUserInfo
@@ -52,7 +53,7 @@ class OAuthAttributes(
                     ofGoogle(userNameAttributeName, attributes)
                 }
                 else -> {
-                    throw RuntimeException()
+                    throw InvalidSocialTypeException()
                 }
             }
         }


### PR DESCRIPTION
## 개요
* 소셜 타입이 올바르지 않을때 커스텀 예외를 반환하도록 리펙토링합니다.
## 작업내용
* OAuthAttributes에서 올바르지 않은 소셜 타입일때 커스텀 예외를 반환하도록 수정